### PR TITLE
setup.py: re-enable long_description_content_type

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
     version=about['__version__'],
     description=DESCRIPTION,
     long_description=long_description,
-    #long_description_content_type='text/markdown',
+    long_description_content_type='text/markdown',
     author=AUTHOR,
     author_email=EMAIL,
     python_requires=REQUIRES_PYTHON,


### PR DESCRIPTION
Fix the description on pypi. You need a recent-ish version of setuptools to get this to work - maybe you didn't have it before?